### PR TITLE
Handle KB in memory

### DIFF
--- a/dockerclustermon/__init__.py
+++ b/dockerclustermon/__init__.py
@@ -251,11 +251,13 @@ def reduce_lines(joined: list[dict[str, str]]) -> list[dict[str, str]]:
             "CPU": str(int(float(j["CPU %"].replace("%", "")))) + " %",
             "Mem": j["MEM USAGE"]
             .replace("MB", " MB")
+            .replace("KB", " KB")
             .replace("GB", " GB")
             .replace("  ", " "),
             "Mem %": str(int(float(j["MEM %"].replace("%", "")))) + " %",
             "Limit": j["MEM LIMIT"]
             .replace("MB", " MB")
+            .replace("KB", " KB")
             .replace("GB", " GB")
             .replace("  ", " "),
         }


### PR DESCRIPTION
Possibly closes #1 

In the [docker docs](https://docs.docker.com/reference/cli/docker/container/stats/#examples) it looks like memory could be reported in KiB and that isn't handled in `reduce_lines`. Maybe that is the cause for the error in #1?