### PR TITLE
Add support to SSH Config and sudo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You can optionally pass the username if you're not logging in as `root`. Here is
 ╰───────────────────────────────────────────────────────────────────────╯
 ╭─ Options ─────────────────────────────────────────────────────────────╮
 | --ssh-config    Whether the host is a SSH config entry or not.        |
+| --sudo          Whether to run as the super user or not.              |
 │ --help          Show this message and exit.                           │
 ╰───────────────────────────────────────────────────────────────────────╯
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You can optionally pass the username if you're not logging in as `root`. Here is
 │                       with the server. [default: root]                │
 ╰───────────────────────────────────────────────────────────────────────╯
 ╭─ Options ─────────────────────────────────────────────────────────────╮
+| --ssh-config    Whether the host is a SSH config entry or not.        |
 │ --help          Show this message and exit.                           │
 ╰───────────────────────────────────────────────────────────────────────╯
 ```

--- a/dockerclustermon/__init__.py
+++ b/dockerclustermon/__init__.py
@@ -1,6 +1,6 @@
 """dockerclustermon - A CLI tool for a live view of your docker containers running on a remote server."""
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __author__ = 'Michael Kennedy <michael@talkpython.fm>'
 __all__ = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dockerclustermon"
-version = "0.2.2"
+version = "0.2.3"
 description = "A CLI tool for a live view of your docker containers running on a remote server."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Hello Michael,

First of all, I would like to thank you for pushing online this very nice tool.  
I like its simplicity, and immediately found a daily usage in it.

I quickly realized I was missing few features (mostly related to my own development environment):

- Ability to connect using an **SSH Config** entry (in such case, no password is required when a private key is used).
- If the user used to SSH connect is not member of the group `docker`, but is a `sudoers`, then running the Docker command prefixed with **sudo** is required.

I added support to both features, which involved a bit of refactoring.

I allowed myself to increase the version number (but it is in a separate commit, so it can be easily reversed).

I hope the coding style used matches your own standards.

Best regards.

Michel